### PR TITLE
do not send local4 log stream (auditd) to papertrail

### DIFF
--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -4,4 +4,4 @@ $ActionSendStreamDriver gtls
 $ActionSendStreamDriverMode 1
 $ActionSendStreamDriverAuthMode x509/name
 
-*.*	@@<%= @log_host %>:<%= @log_port %>
+*.*;local4.none	@@<%= @log_host %>:<%= @log_port %>


### PR DESCRIPTION
We rather annoyingling have 2 subsystems sending data to papertrail on subs systems. The papertrail remote_syslog application and rsyslog iteself. This is not ideal but livable. 

Currently rsyslog sends auditd messages to papertrail and our remote logged server. As we have discovered recently, sub.cron.1 produces an inordinate amount of logs due largely to auditd and the fact that it is a cron system that runs a bunch of shells scripts going about its business. We are blowing our papertrail budget. 

Since papertrail is largely a helper system and not strictly speaking a component of our PCI DSS requirements I suggest we remove the auditd part of the logging for subs. 

This PR prevents auditd picking up local4 events (auditd and audisp) being sent to papertrail. 

The auditd dispatcher syslog plugin configuration (below) informs me that it is using local4.

```
root@cron:/etc/audisp/plugins.d# cat syslog.conf 
# This file controls the configuration of the syslog plugin.
# It simply takes events and writes them to syslog. The
# arguments provided can be the default priority that you
# want the events written with. And optionally, you can give
# a second argument indicating the facility that you want events
# logged to. Valid options are LOG_LOCAL0 through 7.

active = yes
direction = out
path = builtin_syslog
type = builtin 
args = LOG_LOCAL4
format = string
root@cron:/etc/audisp/plugins.d# 
```