### PR TITLE
fix the remote-syslog2 package name so it does not re-install every 6…

### DIFF
--- a/manifests/systemd.pp
+++ b/manifests/systemd.pp
@@ -6,25 +6,25 @@ class papertrail::systemd {
     notify  => Service['remote_syslog']
   }
 
-  file { "/tmp/remote-syslog2_0.19_amd64.deb":
+  file { '/tmp/remote-syslog2_0.19_amd64.deb':
     owner   => root,
     group   => root,
     mode    => 644,
     ensure  => present,
-    source  => "puppet:///modules/papertrail/remote-syslog2_0.19_amd64.deb"
+    source  => 'puppet:///modules/papertrail/remote-syslog2_0.19_amd64.deb'
   }
 
-  package { "remote_syslog":
+  package { 'remote-syslog2':
    provider => dpkg,
    ensure   => installed,
-   source   => "/tmp/remote-syslog2_0.19_amd64.deb",
+   source   => '/tmp/remote-syslog2_0.19_amd64.deb',
    require     => File['/tmp/remote-syslog2_0.19_amd64.deb'],
   }
 
   service { 'remote_syslog':
     ensure      => running,
     provider    => 'systemd',
-    require     => Package['remote_syslog'],
+    require     => Package['remote-syslog2'],
   }
 
   service { 'rsyslog':


### PR DESCRIPTION
The package name that the system searches for is wrong, so puppet re-installs and restarts systemd every 60 seconds. This hopefully remedies that problem.